### PR TITLE
Simplify sugars interfaces and usage, Fix Schema class name

### DIFF
--- a/src/ast/AstHandler.ts
+++ b/src/ast/AstHandler.ts
@@ -1,5 +1,5 @@
 import { BlockHandler } from "../parser/BlockHandler";
-import { InlineHandler, NamedSugar } from "../parser/InlineHandler";
+import { InlineHandler, Sugar } from "../parser/InlineHandler";
 import { InlineParser } from "../parser/InlineParser";
 import { BlockElement, InlineElement, InlineGroup } from "./ast";
 
@@ -78,7 +78,7 @@ export class AstHandler
 		}
 	}
 
-	getAllSugars(): NamedSugar[] {
+	get allSugars(): Sugar[] {
 		return [];
 	}
 }

--- a/src/ir/IRBlockHandler.ts
+++ b/src/ir/IRBlockHandler.ts
@@ -7,7 +7,7 @@ import {
 	ErrorLogger,
 	UnknownBlockTagError
 } from "../schema/errors";
-import { SchemaDecorator } from "../schema/Schema";
+import { Schema } from "../schema/Schema";
 import { ROOT } from "../schema/SchemaDefinition";
 import { IRInlineHandler } from "./IRInlineHandler";
 import { emptyBlockProps, IRNode, IRNodeList } from "./IRNode";
@@ -15,7 +15,7 @@ import { emptyBlockProps, IRNode, IRNodeList } from "./IRNode";
 export class IRBlockHandler implements BlockHandler<IRNode | null> {
 	protected readonly inlineParser: InlineParser<IRNodeList | null, IRNode | null, string>;
 
-	constructor(private readonly schema: SchemaDecorator, private readonly log: ErrorLogger) {
+	constructor(private readonly schema: Schema, private readonly log: ErrorLogger) {
 		this.inlineParser = new InlineParser(new IRInlineHandler(schema, log));
 	}
 

--- a/src/ir/IRInlineHandler.ts
+++ b/src/ir/IRInlineHandler.ts
@@ -1,10 +1,10 @@
 import { DisallowedArgError, ErrorLogger } from "..";
-import { InlineContext, InlineHandler, NamedSugar } from "../parser/InlineHandler";
-import { SchemaDecorator } from "../schema/Schema";
+import { InlineContext, InlineHandler, Sugar } from "../parser/InlineHandler";
+import { Schema } from "../schema/Schema";
 import { emptyBlockProps, IRNode, IRNodeList } from "./IRNode";
 
 export class IRInlineHandler implements InlineHandler<IRNodeList | null, IRNode | null, string> {
-	constructor(private schema: SchemaDecorator, private readonly logger: ErrorLogger) {}
+	constructor(private schema: Schema, private readonly logger: ErrorLogger) {}
 
 	private isRawHead(parentTag: string): boolean {
 		const parentSchema = this.schema.getBlockSchema(parentTag);
@@ -14,12 +14,8 @@ export class IRInlineHandler implements InlineHandler<IRNodeList | null, IRNode 
 
 	rootInlineTag(parentTag: string): InlineContext<IRNodeList> {
 		const parentSchema = this.schema.getBlockSchema(parentTag);
-		const sugars = parentSchema ? parentSchema.headTokenToSugar : new Map<string, NamedSugar>();
-		return {
-			data: [],
-			raw: this.isRawHead(parentTag),
-			sugars
-		};
+		const sugars = parentSchema ? parentSchema.headSugarsByStart : new Map();
+		return { data: [], raw: this.isRawHead(parentTag), sugars };
 	}
 
 	openInlineTag(
@@ -78,7 +74,7 @@ export class IRInlineHandler implements InlineHandler<IRNodeList | null, IRNode 
 		}
 	}
 
-	getAllSugars(): NamedSugar[] {
+	get allSugars(): Sugar[] {
 		return this.schema.allSugars;
 	}
 }

--- a/src/parser/InlineHandler.ts
+++ b/src/parser/InlineHandler.ts
@@ -1,4 +1,4 @@
-import { SugarDefinition } from "../schema/SchemaDefinition";
+import { SugarSyntax } from "../schema/SchemaDefinition";
 
 /**
  * Takes instructions from [[InlineParser]] in order to build an AST.
@@ -19,17 +19,18 @@ export interface InlineHandler<InlineGroupData, InlineData, ParentData = undefin
 		start: number
 	): InlineContext<InlineGroupData>;
 	pushText(parent: InlineGroupData, content: string): void;
-	getAllSugars(): NamedSugar[];
+	allSugars: Sugar[];
 }
 
 export interface InlineContext<InlineGroupData> {
 	raw: boolean;
-	sugars: SugarsMap;
+	sugars: SugarsByStart;
 	data: InlineGroupData;
 }
 
-export interface NamedSugar extends SugarDefinition {
+export interface Sugar {
 	tag: string;
+	syntax: SugarSyntax;
 }
 
-export type SugarsMap = Map<string, NamedSugar>;
+export type SugarsByStart = Map<string, Sugar>;

--- a/src/schema/Schema.ts
+++ b/src/schema/Schema.ts
@@ -1,61 +1,63 @@
-import { NamedSugar } from "../parser/InlineHandler";
+import { Sugar, SugarsByStart } from "../parser/InlineHandler";
 import {
 	BlockSchemaDefinition,
 	InlinePropDefinition,
 	InlineSchemaDefinition,
 	INVALID_TAG,
 	SchemaDefinition,
-	SugarDefinition
+	SugarSyntax
 } from "./SchemaDefinition";
 
-export class SchemaDecorator {
-	private readonly blockSchemas: Map<string, BlockSchemaDecorator> = new Map();
-	private readonly inlineSchemas: Map<string, InlineSchemaDecorator> = new Map();
+type SugarsByTag = Map<string, Sugar>;
 
-	readonly allSugars: NamedSugar[];
+export class Schema {
+	private readonly blockSchemas: Map<string, BlockSchema> = new Map();
+	private readonly inlineSchemas: Map<string, InlineSchema> = new Map();
+
+	readonly allSugars: Sugar[];
 
 	constructor(schema: SchemaDefinition) {
-		const sugars = this.getSugars(schema);
-		this.allSugars = Array.from(sugars.values());
+		const allSugars = Schema.getSugars(schema);
+		this.allSugars = Array.from(allSugars.values());
 
 		for (const [tag, inlineSchema] of Object.entries(schema.inline)) {
-			this.inlineSchemas.set(tag, new InlineSchemaDecorator(inlineSchema, sugars));
+			this.inlineSchemas.set(tag, new InlineSchema(inlineSchema, allSugars));
 		}
 
 		for (const [tag, blockSchema] of Object.entries(schema.blocks)) {
-			this.blockSchemas.set(tag, new BlockSchemaDecorator(blockSchema, sugars));
+			this.blockSchemas.set(tag, new BlockSchema(blockSchema, allSugars));
 		}
 	}
 
 	// Create a map of tag => sugar
-	private getSugars(schema: SchemaDefinition): Map<string, NamedSugar> {
-		const sugars = new Map();
+	private static getSugars(schema: SchemaDefinition): SugarsByTag {
+		const sugars = new Map<string, Sugar>();
 		for (const [tag, { sugar }] of Object.entries(schema.inline)) {
-			if (sugar) sugars.set(tag, { tag, ...sugar });
+			if (sugar) sugars.set(tag, { tag, syntax: sugar });
 		}
 		return sugars;
 	}
 
-	getBlockSchema(tag: string): BlockSchemaDecorator | undefined {
+	getBlockSchema(tag: string): BlockSchema | undefined {
 		return this.blockSchemas.get(tag) || this.blockSchemas.get(INVALID_TAG);
 	}
 
-	getInlineSchema(tag: string): InlineSchemaDecorator | undefined {
+	getInlineSchema(tag: string): InlineSchema | undefined {
 		return this.inlineSchemas.get(tag) || this.inlineSchemas.get(INVALID_TAG);
 	}
 }
 
-export class BlockSchemaDecorator {
+export class BlockSchema {
 	private childTagToProp: Map<string, string> = new Map();
 
 	readonly defaultTag?: string;
 	readonly head?: InlinePropDefinition;
-	readonly headTokenToSugar: Map<string, NamedSugar> = new Map();
+	readonly headSugarsByStart: SugarsByStart = new Map();
 
 	readonly propNames: string[];
 	readonly rawPropName?: string;
 
-	constructor(schema: BlockSchemaDefinition, sugars: Map<string, NamedSugar>) {
+	constructor(schema: BlockSchemaDefinition, allSugars: SugarsByTag) {
 		this.head = schema.head;
 		this.defaultTag = schema.defaultTag;
 
@@ -63,10 +65,7 @@ export class BlockSchemaDecorator {
 
 		if (schema.head) {
 			propsSet.add(schema.head.name);
-			if (!schema.head.raw) {
-				const tags = schema.head.content.map(_ => _.tag);
-				this.headTokenToSugar = propSugarMap(tags, sugars);
-			}
+			this.headSugarsByStart = getSugarsByStart(schema.head, allSugars);
 		}
 
 		for (const prop of schema.props) {
@@ -87,26 +86,20 @@ export class BlockSchemaDecorator {
 	}
 }
 
-export class InlineSchemaDecorator {
+export class InlineSchema {
 	readonly numberArgs: number;
-	readonly sugar?: SugarDefinition;
+	readonly sugar?: SugarSyntax;
 	readonly propNames: string[];
 
-	// arg name => sugar start token => Sugar
-	private readonly argTokenToSugar: Map<string, Map<string, NamedSugar>> = new Map();
+	private readonly argsSugarsByStarts: SugarsByStart[];
 	private readonly props: InlinePropDefinition[];
 
-	constructor(schema: InlineSchemaDefinition, sugars: Map<string, NamedSugar>) {
+	constructor(schema: InlineSchemaDefinition, allSugars: SugarsByTag) {
 		this.numberArgs = schema.props.length;
 		this.sugar = schema.sugar;
 		this.props = schema.props;
 		this.propNames = schema.props.map(_ => _.name);
-		for (const prop of schema.props) {
-			if (!prop.raw) {
-				const tags = prop.content.map(_ => _.tag);
-				this.argTokenToSugar.set(prop.name, propSugarMap(tags, sugars));
-			}
-		}
+		this.argsSugarsByStarts = schema.props.map(_ => getSugarsByStart(_, allSugars));
 	}
 
 	getArgName(index: number): string {
@@ -117,16 +110,18 @@ export class InlineSchemaDecorator {
 		return Boolean(this.props[index].raw);
 	}
 
-	getAllowedSugars(index: number): Map<string, NamedSugar> {
-		return this.argTokenToSugar.get(this.getArgName(index)) || new Map();
+	getAllowedSugars(index: number): SugarsByStart {
+		return this.argsSugarsByStarts[index];
 	}
 }
 
-function propSugarMap(tags: string[], sugars: Map<string, NamedSugar>): Map<string, NamedSugar> {
+function getSugarsByStart(prop: InlinePropDefinition, allSugars: SugarsByTag): SugarsByStart {
+	if (prop.raw) return new Map();
+	const tags = prop.content.map(_ => _.tag);
 	const values = tags
-		.map(tag => sugars.get(tag))
-		.filter((sugar): sugar is NamedSugar => sugar !== undefined);
-	return indexBy(sugar => sugar.start, values);
+		.map(tag => allSugars.get(tag))
+		.filter((sugar): sugar is Sugar => sugar !== undefined);
+	return indexBy(sugar => sugar.syntax.start, values);
 }
 
 function indexBy<K, V>(keyGetter: (item: V) => K, array: V[]): Map<K, V> {

--- a/src/schema/SchemaDefinition.ts
+++ b/src/schema/SchemaDefinition.ts
@@ -49,7 +49,7 @@ export const enum Cardinality {
 
 export interface InlineSchemaDefinition {
 	props: InlinePropDefinition[];
-	sugar?: SugarDefinition;
+	sugar?: SugarSyntax;
 }
 
 export type InlinePropDefinition =
@@ -66,7 +66,7 @@ export type InlinePropDefinition =
 			}>;
 	  };
 
-export interface SugarDefinition {
+export interface SugarSyntax {
 	start: string;
 	separator?: string;
 	end: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,14 @@
 // From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
-export function escapeRegExp(regexp: string): string {
-	return regexp.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
+export function stringToRegexp(regexp: string): RegExp {
+	return new RegExp(regexp.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")); // $& means the whole matched string
+}
+
+export function regexpUnion(...regExps: RegExp[]): RegExp {
+	return new RegExp("(" + regExps.map(_ => `(?:${_.source})`).join("|") + ")", "g");
+}
+
+export function unique<T>(seq: Iterable<T>): T[] {
+	return [...new Set<T>(seq)];
 }
 
 export function last<T>(seq: ArrayLike<T>): T {

--- a/test/parser/TestHandler.ts
+++ b/test/parser/TestHandler.ts
@@ -3,29 +3,24 @@ import { AstHandler } from "../../src/ast/AstHandler";
 
 const sugars = [
 	{
-		start: "`",
-		end: "`",
+		syntax: { start: "`", end: "`" },
 		tag: "code"
 	},
 	{
-		start: "*",
-		end: "*",
+		syntax: { start: "*", end: "*" },
 		tag: "strong"
 	},
 	{
-		start: "_",
-		end: "_",
+		syntax: { start: "_", end: "_" },
 		tag: "emphasis"
 	},
 	{
-		start: "{",
-		separator: "|",
-		end: "}",
+		syntax: { start: "{", separator: "|", end: "}" },
 		tag: "set"
 	}
 ];
 
-const sugarsMap = new Map(sugars.map(_ => [_.start, _]));
+const sugarsMap = new Map(sugars.map(_ => [_.syntax.start, _]));
 
 export class TestHandler extends AstHandler {
 	openBlock(
@@ -66,7 +61,7 @@ export class TestHandler extends AstHandler {
 		};
 	}
 
-	getAllSugars() {
+	get allSugars() {
 		return sugars;
 	}
 }

--- a/test/parser/parseIRTest.ts
+++ b/test/parser/parseIRTest.ts
@@ -2,7 +2,7 @@ import { assert } from "chai";
 import { BlockParser, DisallowedDefaultTagError, HMError, UnknownBlockTagError } from "../../src";
 import { IRBlockHandler } from "../../src/ir/IRBlockHandler";
 import { IRNode } from "../../src/ir/IRNode";
-import { SchemaDecorator } from "../../src/schema/Schema";
+import { Schema } from "../../src/schema/Schema";
 import {
 	Cardinality,
 	INVALID_TAG,
@@ -21,7 +21,7 @@ describe("IRHandler", () => {
 
 	let parser: BlockParser<IRNode | null>;
 	const makeParser = (schema: SchemaDefinition) => {
-		parser = new BlockParser(new IRBlockHandler(new SchemaDecorator(schema), logger));
+		parser = new BlockParser(new IRBlockHandler(new Schema(schema), logger));
 	};
 
 	describe("empty-schema", () => {


### PR DESCRIPTION
- `InlineParser` constructor is simplified.
- `SugarsByTag` and `SugarByStart` types are used to clarify types of sugars maps.
- `SugarDefinition` is renamed to `SugarSyntax`,
- `NamedSugar: {tag, start, separator, end}` is transformed to `Sugar: {tag, syntax: SugarSyntax}`,
- `SchemaDecorator` is renamed to`Schema`, same for `BlockSchema` and `InlineSchema`.